### PR TITLE
chore: fix when db is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@koralabs/hal-minting-contracts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@koralabs/hal-minting-contracts",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@aiken-lang/merkle-patricia-forestry": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@koralabs/hal-minting-contracts",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "main": "index.js",
   "type": "module",

--- a/src/txs/prepareMint.ts
+++ b/src/txs/prepareMint.ts
@@ -359,8 +359,12 @@ const prepareMintTransaction = async (
   // update whitelist data
   const newMintingData: MintingData = {
     ...mintingData,
-    mpt_root_hash: db.hash.toString("hex"),
-    whitelist_mpt_root_hash: whitelistDB.hash.toString("hex"),
+    mpt_root_hash: (
+      db.hash?.toString("hex") || Buffer.alloc(32).toString("hex")
+    ).toLowerCase(),
+    whitelist_mpt_root_hash: (
+      whitelistDB.hash?.toString("hex") || Buffer.alloc(32).toString("hex")
+    ).toLowerCase(),
   };
 
   // minting data asset value


### PR DESCRIPTION
## Changes

* Use empty 32 bytes `0` when merkle trie is empty