### PR TITLE
test: add prepare orders unit coverage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,17 @@
 # Documentation
 
+This repo's documentation is split between product-facing operating context and technical implementation detail. Together they describe how H.A.L. minting works, which files are the source of truth for deployment, and how the contract suite is validated.
+
 ## Product
 - [Product Index](./product/index.md)
 - [PRD](./product/prd.md)
 - [Feature Matrix](./product/feature-matrix.md)
 - [Minting Lifecycle](./product/minting-lifecycle.md)
+- [Operations Model](./product/operations-model.md)
 
 ## Spec
 - [Spec Index](./spec/index.md)
 - [Technical Spec](./spec/spec.md)
 - [Contract Deployment Pipeline](./spec/contract-deployment-pipeline.md)
 - [Data Model](./spec/data-model.md)
+- [Validator Catalog](./spec/validator-catalog.md)

--- a/docs/product/index.md
+++ b/docs/product/index.md
@@ -1,5 +1,12 @@
 # Product Docs
 
-- [PRD](./prd.md)
-- [Feature Matrix](./feature-matrix.md)
-- [Minting Lifecycle](./minting-lifecycle.md)
+`hal-minting-contracts` is the contract and operator-facing runtime that turns a fixed H.A.L. collection into a controllable minting system. The product docs in this folder explain the business rules behind the collection, the minting journey that users indirectly experience, and the operational model that Kora operators follow when they change scripts or settings.
+
+- [PRD](./prd.md)  
+  Product goals, actors, requirements, and success criteria for the H.A.L. minting system.
+- [Feature Matrix](./feature-matrix.md)  
+  Quick capability-to-module map for the major contract, transaction, and CLI surfaces.
+- [Minting Lifecycle](./minting-lifecycle.md)  
+  End-to-end path from order placement through batch minting, metadata routing, and post-mint admin flows.
+- [Operations Model](./operations-model.md)  
+  Role boundaries, source-of-truth rules, deployment readiness expectations, and day-2 operator responsibilities.

--- a/docs/product/operations-model.md
+++ b/docs/product/operations-model.md
@@ -1,0 +1,143 @@
+# Operations Model
+
+## Purpose
+This repo is not only a library of smart-contract helpers. It is also the operational control surface for how H.A.L. minting is rolled out, governed, and kept safe across `preview`, `preprod`, and `mainnet`. The contracts, desired deployment YAML, interactive scripts, and tests work together to answer four operator questions:
+
+1. What scripts and settings should be live on each network?
+2. Which actor is allowed to perform each minting or admin action?
+3. What local and on-chain state must match before a mint can proceed?
+4. How do operators detect drift before a rollout becomes unsafe?
+
+## Roles And Responsibilities
+
+### End user
+- Places an order that pays the required lovelace to the orders script.
+- Does not choose the specific H.A.L. asset datum at order-sign time.
+- Can cancel their own order while it is still unconsumed.
+
+### Allowed minter / batcher
+- Is the only signer allowed to execute the actual mint path.
+- Collects order UTxOs, groups them into mintable batches, and signs the final mint transaction.
+- Is also the actor allowed to issue scripted refunds when an order is invalid or no longer processable.
+
+### Minting-data admin
+- Controls the `admin_verification_key_hash` parameter on the minting-data validator.
+- Can update the minting-data root structure without minting a user NFT when operationally required.
+- Must never be treated as a substitute for the allowed minter; the role exists for root management, not for bypassing mint validation.
+
+### Ref-spend admin
+- Governs reference-token datum updates after mint.
+- Uses the ref-spend settings handle plus the ref-spend validator path to authorize metadata replacement.
+
+### Royalty admin
+- Controls the royalty datum at the royalty-spend validator.
+- Can mint the one royalty NFT and later update the royalty datum when policy or payout configuration changes.
+
+### Deployment operator
+- Owns the desired-state YAML files under `deploy/`.
+- Runs the deployment planner to compare desired state with current chain state.
+- Prepares approval artifacts for human review but does not bypass the wallet approval boundary.
+
+## Canonical Sources Of Truth
+
+### Desired state
+The committed YAML files under `deploy/preview`, `deploy/preprod`, and `deploy/mainnet` are the canonical description of what should be live. They define:
+- contract build parameters,
+- static settings values,
+- stable handle assignments,
+- the set of supported contracts,
+- which minting-data fields are intentionally ignored for drift.
+
+For deployment planning, these files win over everything else in the repo.
+
+### Live state
+Live state is fetched from chain and handle API endpoints at plan time. It includes:
+- currently published script hashes,
+- currently assigned SubHandles,
+- handle-backed settings datums,
+- handle-backed minting-data roots.
+
+Live state is informational and should never be committed back into desired-state YAML when it contains volatile references such as UTxO ids or observed timestamps.
+
+### Legacy or operator-local config
+The interactive CLI modules in `scripts/configs/*.ts` remain useful for ad hoc contract export, datum CBOR generation, and staking-address registration. They are not the authoritative deployment source of truth. If a value in `scripts/configs/*.ts` diverges from `deploy/*.yaml`, the deployment planner follows the YAML because those files are what CI and approval-ready artifacts consume.
+
+## Environment Model
+
+### Preview
+- Lowest-risk environment for contract and handle rollout rehearsal.
+- May intentionally tolerate partial settings handle coverage while the new deployment system is being adopted.
+- Best place to validate desired-state schema changes and planner artifact formatting.
+
+### Preprod
+- Dress rehearsal environment for mainnet-intended topology.
+- Useful for validating handle allocation, script-hash drift classification, and live settings decoding against a public network.
+
+### Mainnet
+- Production environment with real economic consequences.
+- Requires the strongest discipline around source-of-truth, signer control, and rollout review.
+- Should be treated as approval-gated even when deployment planning is fully automated.
+
+## Operational Flow
+
+### 1. Prepare local state
+- Confirm the repo is on the correct branch and the desired YAML for the target network is current.
+- Make sure the MPT and whitelist databases reflect the intended mintable inventory and whitelist allocations.
+- Verify environment variables such as `BLOCKFROST_API_KEY`, `KORA_USER_AGENT`, and any API endpoint overrides are present for the network being used.
+
+### 2. Plan deployment or minting work
+- For deployments, run the planner against a committed desired YAML path.
+- For minting, fetch settings, minting-data, deployed scripts, and current order UTxOs.
+- In both cases, treat stale local roots or stale handle-backed settings as a blocking condition rather than something to patch around.
+
+### 3. Build artifacts
+- Deployment work produces summary and plan artifacts.
+- Minting work produces a transaction builder plus user outputs, reference outputs, and updated trie state.
+- Settings and ref-spend settings CBOR may be produced from the interactive CLI when operators need a wallet-ready payload.
+
+### 4. Human approval or signer action
+- Minting requires the allowed minter signature.
+- Royalty and ref-datum updates require their respective admin signatures.
+- Deployment remains human-approved at the wallet boundary even when the plan generation is automated.
+
+### 5. Post-action verification
+- Confirm that script hashes, settings handles, or minting-data roots match the expected post-action state.
+- For minting, verify that user assets and reference assets were routed correctly and that local trie state has moved from available to consumed.
+
+## Readiness Checklist
+
+### Before a mint batch
+- Settings datum decodes successfully.
+- Minting-data datum decodes successfully.
+- Local asset trie root equals on-chain `mpt_root_hash`.
+- Local whitelist trie root equals on-chain `whitelist_mpt_root_hash`.
+- Orders selected for the batch are valid and within configured amount limits.
+- Enough asset names and metadata payloads exist for the batch.
+- The allowed minter wallet has collateral and can sign.
+
+### Before a deployment review
+- Desired YAML validates under `src/deploymentState.ts`.
+- The planner can derive expected hashes from the requested build parameters.
+- Handle assignment names fit the repo's slug and ordinal rules.
+- Reviewers understand whether the change is script drift, settings drift, or both.
+
+## Failure Modes That Must Be Treated Seriously
+- Root-hash mismatch between local tries and on-chain minting-data.
+- Orders that encode an invalid destination, invalid amount, or incorrect payment.
+- Missing reference script UTxOs for any of the deployed contracts.
+- Planner input that includes observed-only fields or invalid handle slugs.
+- Manual operator assumptions that use `scripts/configs/*.ts` as deployment truth after the committed YAML has changed.
+
+## Non-Acceptable Workarounds
+- Skipping root comparisons to force a mint through.
+- Editing desired YAML to mirror accidental live drift without understanding the cause.
+- Refunding or cancelling through the wrong signer path.
+- Treating preview success as sufficient proof for mainnet if the desired YAML or handle assignments differ.
+
+## Documentation Expectations
+Because this repo is both a contract package and an operations repo, docs have to explain more than transaction builders. A useful update should clarify:
+- who signs what,
+- where the canonical values live,
+- how drift is detected,
+- which invariants are hard blockers,
+- how to tell the difference between an intended rollout and stale operational state.

--- a/docs/product/prd.md
+++ b/docs/product/prd.md
@@ -1,69 +1,154 @@
 # HAL Minting Contracts PRD
 
 ## Summary
-`hal-minting-contracts` delivers smart-contract packaging and off-chain SDK flows for minting pre-defined H.A.L NFT assets, including order intake, whitelist discount handling, reference-token routing, and royalty metadata control.
+`hal-minting-contracts` provides the on-chain scripts, off-chain transaction builders, deployment-planning logic, and operator tooling required to mint a fixed H.A.L. NFT collection safely. The core product promise is simple: users can request mints for a pre-defined collection, operators can batch those requests efficiently, and the system guarantees that only allowed assets are minted while whitelist and governance rules remain enforceable on-chain.
 
-## Problem
-H.A.L minting needs deterministic controls for:
-- Reserving and minting only pre-defined assets.
-- Enforcing ordered mint amounts and payment constraints.
-- Supporting whitelist-based early-access discounts.
-- Updating CIP-68 reference metadata and royalty configuration through authorized flows.
+This repo sits between product policy and chain execution. It does not render storefront UI, but it defines the business rules that every storefront, operator, and deployment workflow must obey.
 
-## Users
-- Kora Labs operators and batchers executing mint runs.
-- Internal tooling that prepares and submits mint/order/refund transactions.
-- Contract deployment operators publishing script artifacts and settings datums.
+## Background
+The H.A.L. collection contains a pre-defined universe of 10,000 asset names. The system is intentionally designed so that users do not learn the specific asset datum at order-sign time. Instead, users place an order UTxO, and an allowed batcher later consumes those orders and mints the final NFT plus its paired reference token. This avoids a predictable exploit where a user inspects metadata before signing and only authorizes transactions containing especially desirable assets.
 
-## Goals
-- Keep mint eligibility chain-accurate via MPT proofs and root-hash checks.
-- Allow users to place/cancel orders while preserving batcher-managed mint execution.
-- Integrate whitelist windows and discounted mint logic without breaking deterministic validation.
-- Provide deploy, staking, royalty, and ref-update helper APIs for operations.
+The repo also supports whitelist-based early access and discounted minting. That means product requirements are not limited to "mint one NFT"; they also include time-window enforcement, deterministic pricing, controlled metadata evolution, and deployment safety across multiple networks.
+
+## Problem Statement
+The minting system must solve all of the following at once:
+- preserve a fixed collection of allowable asset names,
+- prevent double minting,
+- allow users to submit orders without seeing the final metadata datum,
+- let trusted operators batch work efficiently,
+- support early-access windows for approved wallets,
+- manage post-mint reference datum and royalty state through governed flows,
+- keep deployment state understandable and reviewable before any production rollout.
+
+If any one of these controls is weak, the collection becomes economically or reputationally unsafe. As a result, the product must prefer deterministic validation and clear operator workflows over convenience shortcuts.
+
+## Users And Actors
+
+### End users
+- Want to request one or more H.A.L. mints.
+- Care that pricing is correct, orders can be cancelled when needed, and received NFTs match the collection rules.
+
+### Allowed minters / batchers
+- Need efficient tools for collecting order UTxOs and producing mint transactions.
+- Need chain-accurate proof generation and predictable failure behavior.
+
+### Contract and deployment operators
+- Need deterministic contract export, desired-state YAML, and drift reports.
+- Need to know which values are safe to change and which changes imply a new script hash or handle migration.
+
+### Governance admins
+- Need controlled flows for royalty datum updates, ref-datum updates, and minting-data root management.
+
+## Product Goals
+- Guarantee that only pre-defined H.A.L. asset names can be minted.
+- Guarantee that an already-consumed asset name cannot be minted again.
+- Allow trusted batchers to mint many user orders in a single transaction without compromising correctness.
+- Support whitelist windows and discounted pricing in a way that is deterministic and auditable on-chain.
+- Keep reference-token and royalty governance separate from end-user minting.
+- Make deployment drift visible before any human signs a rollout.
 
 ## Non-Goals
-- Public web storefront implementation.
-- User wallet UX/UI.
-- Generic NFT mint engine not tied to H.A.L contract model.
+- Public storefront or wallet UX.
+- General-purpose NFT minting outside the H.A.L. collection model.
+- Automatic self-healing deployment bots that bypass human review.
+- Hidden retries or silent fallbacks that conceal source-of-truth mismatches.
+
+## Product Principles
+
+### 1. The collection is fixed
+The repo is allowed to change implementation, tooling, or deployment packaging, but it must never change the idea that H.A.L. asset names come from a pre-defined inventory controlled through the minting-data trie.
+
+### 2. Batch efficiency must not weaken fairness
+Batching exists to prevent users from choosing metadata at sign time and to reduce operational overhead. It is not a license to introduce opaque mint rules. Every discount, order selection, and refund path must remain explainable.
+
+### 3. Operators need explicit state, not folklore
+Desired deployment YAML, handle assignments, plan artifacts, and test coverage are all part of the product. Operational ambiguity is a product defect for a contract repo.
+
+### 4. Governance flows must be separate from user mint flows
+Royalty updates, reference datum updates, and minting-data administration exist, but they should each have distinct authorization paths instead of piggybacking on user-order behavior.
 
 ## Functional Requirements
 
-### Orders
-- Build order transactions for one or more `Order` items, bounded by:
-  - max order amount per order,
-  - max order UTxOs per transaction.
-- Support owner cancellation flow.
-- Support minter-authorized refund flow with owner-payment-credential validation.
-- Fetch order UTxOs from deployed `orders_spend` script.
+### Order intake
+- Users can create one or more order outputs in a single request transaction.
+- Each order specifies a destination address, quantity, and paid lovelace amount.
+- Destination addresses must be base addresses rather than validator destinations.
+- Order quantity must be positive and bounded by the configured per-order maximum.
+- A single transaction must not exceed the repo-defined maximum order-UTxO count.
 
-### Mint Preparation and Execution
-- Validate order UTxOs before aggregation.
-- Aggregate valid orders into executable mint groups constrained by:
-  - `maxOrderAmountInOneTx`,
-  - `maxTxsPerLambda`,
-  - `remainingHals`.
-- Build mint proofs from asset trie and whitelist trie.
-- Ensure local MPT and whitelist-MPT roots equal on-chain minting-data roots before tx construction.
-- Mint paired `100` reference and `222` user assets and route outputs correctly.
+### Order cancellation and refund
+- A user can cancel an unconsumed order with the owner signer path.
+- The allowed minter can refund an order through the governed refund path.
+- Refund logic must validate the script source and, when the datum decodes cleanly, must send the refund to the same payment credential that created the order.
 
-### Whitelist Handling
-- Load per-address whitelist value from whitelist trie.
-- Apply time-gap and amount/price rules to determine discounted eligibility.
-- Update whitelist state after order consumption and preserve updated proofs for on-chain validation.
+### Mint preparation
+- Operators can fetch candidate order UTxOs from the deployed orders script.
+- Invalid orders are separated from mintable ones rather than silently ignored.
+- Valid orders are aggregated by destination address and constrained by:
+  - max order amount per mint transaction,
+  - max grouped transactions per lambda/batch,
+  - remaining collection inventory.
+- Aggregation must respect whitelist availability and timing rules before a mint builder is constructed.
 
-### Royalty and Reference Datum Management
-- Mint the royalty NFT to royalty spend script with royalty datum.
-- Update royalty datum with admin-signed transaction.
-- Update reference asset datum through ref spend governance flow.
+### Asset integrity and proofs
+- Every asset minted to a user must correspond to a pre-filled asset name in the local trie.
+- The trie proof for that asset must be included so the on-chain validator can update root state from available to minted.
+- Local asset trie and on-chain minting-data root must match before mint construction begins.
+- The same match requirement applies to whitelist trie state.
 
-### Deployment and Operations
-- Produce deploy payloads for all HAL contracts:
-  - mint proxy, mint withdraw, minting data spend, orders spend,
-  - ref spend proxy, ref spend withdraw, royalty spend.
-- Build settings and ref-spend-settings datum CBOR in CLI.
-- Build staking registration tx CBOR for mint + ref spend governors.
+### Whitelist support
+- The system stores whitelist entitlements in a dedicated trie keyed by destination address.
+- Each whitelist item can encode how early a wallet may mint, how many discounted mints remain, and what discounted price applies.
+- When whitelist entitlements are consumed, the repo must update local whitelist trie state and supply the proof required for on-chain validation.
+
+### Mint execution
+- The allowed minter is the signer that authorizes user NFT minting.
+- Mint execution mints both the user-facing `222` assets and the paired reference `100` assets.
+- Reference outputs must be routed to the ref-spend proxy path for governed datum updates.
+- User outputs must route minted H.A.L. NFTs to the order destination address.
+
+### Royalty and reference governance
+- A governed flow exists to mint the single royalty NFT and lock it at the royalty-spend validator with a royalty datum.
+- A separate admin path can replace the royalty datum later.
+- A ref-spend admin path can replace the datum attached to a reference token after mint.
+
+### Deployment planning
+- The repo must own committed desired state for `preview`, `preprod`, and `mainnet`.
+- The planner must compare desired script hashes and settings values to live state and classify drift.
+- The resulting artifacts must be readable by reviewers before any wallet signing occurs.
+
+## User And Operator Stories
+- As a user, I can place an order for one or more H.A.L. NFTs without needing to know the final metadata datum in advance.
+- As a user, I can cancel my own order if it has not yet been consumed.
+- As a batcher, I can collect valid orders, group them safely, and produce a mint transaction that includes all required proofs.
+- As a batcher, I can distinguish valid, unpicked, and invalid orders so I know what to mint now versus later versus refund.
+- As a governance admin, I can update royalty or reference metadata without changing the user mint path.
+- As a deployment operator, I can tell whether a planned change will rotate a script SubHandle, update settings only, or do nothing at all.
+
+## Product Constraints
+- The repo depends on Cardano script semantics and Helios/Aiken contract packaging.
+- Some flows require live handle API and Blockfrost data to assemble or validate transactions.
+- Human wallet approval remains part of deployment, even when drift detection and artifact generation are automated.
+- Documentation must remain aligned with both the current code and the desired deployment model.
+
+## Quality Requirements
+
+### Correctness
+- No asset outside the pre-defined inventory may be minted.
+- No already-minted asset may be minted again.
+- Reference and royalty flows must not weaken user mint safety.
+
+### Observability
+- Deployment plan output must show enough detail for a reviewer to reason about drift and intended post-deploy state.
+- Tests must cover both emulator mint flows and deployment-planning logic.
+
+### Operator clarity
+- Docs must explain which files are canonical for deployment truth.
+- Admin roles and signer expectations must be explicit.
+- Invariant failures must be treated as blockers, not operational noise.
 
 ## Success Criteria
-- Integration suite (`tests/mint.test.ts`) passes.
-- Coverage guardrail (`test_coverage.sh`) remains >=90% lines and branches.
-- Documentation stays aligned with exported APIs and CLI operational flows.
+- End-to-end mint tests pass, including regular minting, whitelist minting, royalty minting, and reference datum updates.
+- Unit coverage remains strong across runtime helpers, desired deployment parsing, and deployment plan generation.
+- Committed docs make the contract set, deployment state model, and minting lifecycle understandable without reverse-engineering the code.
+- The combined documentation in `docs/product` and `docs/spec` is complete enough for operators and reviewers to reason about this repo without relying on tribal knowledge.

--- a/docs/spec/contract-deployment-pipeline.md
+++ b/docs/spec/contract-deployment-pipeline.md
@@ -1,23 +1,14 @@
 # Contract Deployment Pipeline Spec
 
 ## Repository Scope
-This repo owns the desired on-chain deployment state for H.A.L. minting contracts and their contract-level settings.
+This repo owns the desired on-chain deployment state for the H.A.L. minting contracts and their handle-backed settings assets. It is the place where engineers state what should be live on `preview`, `preprod`, and `mainnet`, not the place where they preserve transient live chain references.
 
-The repo should define what ought to be live on `preview`, `preprod`, and `mainnet`. It should not be treated as the storage location for volatile live references such as current settings UTxO refs.
+The deployment pipeline therefore has two jobs:
+- derive the script hashes and settings that should exist from committed repo state,
+- compare that desired state to live handle and script state without mutating chain state automatically.
 
-Canonical slug naming for this repo follows the shared rule in `adahandle-deployments/docs/contract-deployment-pipeline.md`:
-- `<app><[ord|mnt|ref|roy]><[mpt]>`
-- this repo currently uses `halmntprx`, `halmntmpt`, `halmnt`, `halord`, `halrefprx`, `halref`, and `halroy`
-- `old_script_type` is legacy migration-only
-
-## State Model
-- Desired state lives in committed YAML files in this repo.
-- Observed live state is read from chain UTxOs and deployed script hashes.
-- Operational automation config lives outside this repo in orchestration/control-plane repos.
-- Volatile fields such as `tx_hash`, `output_index`, and current UTxO refs belong in observed-state artifacts, not committed desired-state YAML.
-
-## Desired State Files
-The committed layout is:
+## Canonical Source Of Truth
+The committed YAML files under `deploy/` are authoritative for deployment planning:
 
 ```text
 deploy/preview/hal-minting.yaml
@@ -25,48 +16,18 @@ deploy/preprod/hal-minting.yaml
 deploy/mainnet/hal-minting.yaml
 ```
 
-Each file contains stable desired state only:
+These files define build parameters, static settings, handle assignments, and the set of contracts the repo owns. The interactive configuration modules in `scripts/configs/*.ts` can still be used to generate contract exports or datum CBOR during manual operations, but they are not the canonical desired-state input for CI or drift detection. If those modules diverge from `deploy/*.yaml`, the YAML wins for deployment-review purposes.
 
-```yaml
-schema_version: 2
-network: preview
-build_parameters:
-  mint_version: 0
-  admin_verification_key_hash: <hex>
-  orders_spend_randomizer: ""
-  royalty_spend_admin: <hex>
-settings:
-  hal_settings:
-    allowed_minter: <hex>
-    hal_nft_price: 30000000
-    payment_address: <bech32>
-    minting_start_time: 1757631246160
-  ref_spend_settings:
-    ref_spend_admin: <hex>
-  minting_data:
-    mpt_root_hash: <hex>
-    whitelist_mpt_root_hash: <hex>
-assigned_handles:
-  settings:
-    hal-settings: hal@handle_settings
-    halref-settings: hal_pz@handle_settings
-    halmntmpt-settings: hal_root@handle_settings
-  scripts:
-    halmntprx: hal_mnt_prxy@handle_contract
-ignored_settings:
-  - settings.minting_data.mpt_root_hash
-  - settings.minting_data.whitelist_mpt_root_hash
-contracts:
-  - contract_slug: halmntprx
-    script_type: halmntprx
-    old_script_type: hal_mint_proxy
-    deployment_handle_slug: halmntprx
-    build:
-      contract_name: halmntprx.mint
-      kind: minting_policy
-```
+## Canonical Slug Rules
+This repo follows the shared slug naming rules used by the broader contract deployment system:
+- `<app><[ord|mnt|ref|roy]><[mpt]>`
+- current slugs are `halmntprx`, `halmntmpt`, `halmnt`, `halord`, `halrefprx`, `halref`, and `halroy`
+- `old_script_type` exists only to support live lookups that still use legacy script type names
 
-Required stable fields:
+`contracts[].deployment_handle_slug` must be no more than 10 characters and must not include separators such as `-` or `_` because the final SubHandle format appends an ordinal and the `@handlecontract` namespace.
+
+## Desired State Schema
+The parser in `src/deploymentState.ts` enforces `schema_version: 2` and validates the shape of every desired-state file. Stable fields include:
 - `schema_version`
 - `network`
 - `build_parameters.*`
@@ -82,52 +43,127 @@ Required stable fields:
 - `contracts[].build.contract_name`
 - `contracts[].build.kind`
 
-Observed-only fields that must not be committed into desired-state YAML:
+The parser also prevents accidental configuration drift by rejecting:
+- unsupported networks,
+- unsupported script types,
+- duplicate contract slugs,
+- empty contract arrays,
+- mismatches between `contract_slug`, `script_type`, and `deployment_handle_slug`,
+- observed-only fields that do not belong in committed state.
+
+## Observed-Only Fields
+The following fields are explicitly blocked from desired YAML because they describe live observations rather than intended steady state:
 - `current_script_hash`
 - `current_settings_utxo_ref`
 - `current_subhandle`
 - `observed_at`
 - `last_deployed_tx_hash`
 
-The initial bootstrap job may populate these files from current chain state, but it must strip live-only references before commit.
+This matters because the repo should remain stable and reviewable. A planner that wrote live references back into git would create noise and make true intent harder to audit.
 
-`contracts[].deployment_handle_slug` values must be 10 characters or fewer and must not contain separators such as `-` or `_`.
-`assigned_handles` must record the currently assigned settings and script handles for each network, including `null` where a settings handle is not live yet.
+## Expected Contract Derivation
+`buildExpectedContractStates()` constructs all validator and policy hashes from the desired build parameters by calling `buildContracts()`. This means script drift is never inferred from filenames or assumptions; it is recomputed from the same parameters that actually control the compiled programs:
+- `mint_version`
+- `admin_verification_key_hash`
+- `orders_spend_randomizer`
+- `royalty_spend_admin`
 
-## Drift Detection
-Deployment automation should:
-- build the contract and derive the expected script hash,
-- load desired YAML from this repo,
-- read live chain state for the contract settings UTxO,
-- classify drift as `script_hash_only`, `settings_only`, or `script_hash_and_settings`.
+Each contract entry maps one `build.contract_name` to exactly one derived script hash. If an unsupported contract name appears, plan generation fails immediately.
 
-No deployment artifact should be created when desired and live state already match.
+## Live State Fetching
+The planner reads live state from network-specific handle API endpoints:
+- `https://preview.api.handle.me`
+- `https://preprod.api.handle.me`
+- `https://api.handle.me`
 
-## SubHandle Rules
-- A script hash change requires a new SubHandle in the format `<deployment_handle_slug><ordinal>@handlecontract`.
-- A settings-only change reuses the current SubHandle and moves it forward with the settings UTxO.
-- The next ordinal must be derived from live chain state, not a repo-local counter.
+It fetches:
+- latest deployed script metadata for each contract,
+- the HAL settings handle and datum,
+- the ref-spend settings handle and datum,
+- the minting-data handle, its datum, and its lovelace-bearing UTxO.
+
+All requests require a `User-Agent`, which is why the workflow passes `KORA_USER_AGENT` into `scripts/generateDeploymentPlan.ts`.
+
+Missing live objects are treated as meaningful drift rather than fatal errors when reasonable. For example, a `404` for a script or settings handle can still produce an approval-ready plan that says the live state is missing.
+
+## Drift Classification
+The current planner distinguishes between:
+- `no_change`
+- `script_hash_only`
+- `settings_only`
+
+For contract entries, the current implementation checks whether the live script hash equals the expected one. If not, the entry is marked `script_hash_only` and receives a new or replacement SubHandle plan.
+
+For settings entries, the planner recursively diffs the live handle-backed values against the desired values and marks the entry `settings_only` when rows differ.
+
+## Ignored Settings
+`ignored_settings` exists so the planner can intentionally suppress diff noise for fields that are allowed to vary outside a contract rollout. In this repo, the committed YAML currently ignores the minting-data root hashes:
+- `settings.minting_data.mpt_root_hash`
+- `settings.minting_data.whitelist_mpt_root_hash`
+
+That means the deployment plan still records desired values, but those two fields do not cause settings drift on their own. This is important because minting activity naturally changes those roots.
+
+## SubHandle Allocation Rules
+Script hash changes cannot silently reuse the same `@handlecontract` SubHandle unless the hash is unchanged. The planner discovers the next handle by:
+1. inspecting the current live handle when present,
+2. probing ordinalized candidates such as `halmnt1@handlecontract`,
+3. selecting the next free or reusable ordinal in sequence.
+
+This ensures that script identity changes are visible and that handle movement remains deterministic across environments.
 
 ## Artifact Contract
-The deployment workflow for this repo currently emits:
-- `deployment-plan.json`
-- `summary.md`
+`scripts/generateDeploymentPlan.ts` emits exactly three artifacts today:
 - `summary.json`
+- `summary.md`
+- `deployment-plan.json`
 
-It does not emit `tx-XX.cbor` artifacts yet. Current rollout scope is drift detection plus approval-ready summary generation, with missing or legacy live handles tolerated so partially deployed networks still produce artifacts.
+Each artifact is written into the caller-provided artifacts directory and annotated with:
+- `plan_id`
+- `repo`
+- `network`
+- `tx_artifact_generated: false`
+- `artifact_files`
 
-The canonical observed-state artifact remains JSON, but for HAL it is multi-object:
-- seven contract script entries (`halmntprx`, `halmnt`, `halmntmpt`, `halord`, `halrefprx`, `halref`, `halroy`)
-- three stable settings-handle entries (`hal-settings`, `halref-settings`, `halmntmpt-settings`)
+The absence of CBOR artifacts is intentional. The current rollout model for this repo is planning and review, not fully automated submission.
 
-Each contract entry carries the current script hash and current deployment SubHandle. Each settings entry carries the decoded handle-backed desired values without volatile UTxO refs.
+## Artifact Semantics
+
+### `summary.json`
+- Machine-readable overview of contract and settings drift.
+- Includes script hash comparisons, handle plans, diff rows, and expected post-deploy state.
+
+### `summary.md`
+- Human-readable review summary.
+- Best suited for PR comments, deployment review threads, or artifact inspection without a JSON parser.
+
+### `deployment-plan.json`
+- Normalized post-deploy state object that downstream tooling can consume when a deployment is approved.
 
 ## Human Approval Boundary
-Automation prepares deployment transactions and summaries.
+The planner prepares evidence. It does not sign, submit, or auto-heal. Humans remain responsible for:
+- reviewing the drift classification,
+- deciding whether the change is intended,
+- downloading or generating any wallet-signable artifacts required for the rollout,
+- approving submission through the correct wallet boundary.
 
-Humans remain responsible for:
-- downloading CBOR artifacts,
-- uploading/signing/submitting in Eternl,
-- approving the deployment at the wallet boundary.
+This is especially important for H.A.L. because a bad rollout can alter policy, redirect settings, or break minting governance across environments.
 
-Post-submit automation should verify that chain state converges to the desired YAML plus the expected SubHandle transition.
+## Operational Failure Modes
+- Desired YAML includes observed-only fields and fails schema validation.
+- A contract slug or build name does not map to the supported contract set.
+- Live handle state is missing or malformed.
+- `KORA_USER_AGENT` is absent, causing handle API requests to violate the ecosystem rule for `*.handle.me`.
+- Engineers review `scripts/configs/*.ts` instead of the committed desired YAML and misinterpret what the next rollout should do.
+
+## Expected Workflow
+1. Edit `deploy/<network>/hal-minting.yaml` if desired state truly changed.
+2. Run the deployment planner locally or through CI.
+3. Review `summary.md` and `summary.json`.
+4. Confirm whether the change is:
+   - a script rotation,
+   - a settings-only update,
+   - a no-op.
+5. Obtain human approval before any wallet-signing or submission step.
+6. After rollout, verify that live handles and hashes converge to the repo's desired state.
+
+This workflow keeps the repo honest about the difference between "what is committed," "what is live," and "what has merely been proposed."

--- a/docs/spec/data-model.md
+++ b/docs/spec/data-model.md
@@ -1,81 +1,221 @@
 # Data Model
 
-## Constants and Identifiers
+## Scope
+The H.A.L. minting data model spans more than contract datums. Engineers working in this repo need to reason about:
+- on-chain asset naming conventions,
+- handle-backed settings records,
+- minting-data and whitelist proof payloads,
+- order datums and aggregated order state,
+- deployment-plan YAML and live-state artifacts.
+
+This document ties those shapes together so changes to one layer can be reviewed against the others.
+
+## Constants And Identifiers
 
 | Symbol | Value | Meaning |
 | --- | --- | --- |
-| `PREFIX_100` | `000643b0` | Reference token label |
-| `PREFIX_222` | `000de140` | User NFT label |
-| `SETTINGS_HANDLE_NAME` | `hal@handle_settings` | HAL settings asset |
-| `REF_SPEND_SETTINGS_HANDLE_NAME` | `hal_pz@handle_settings` | Ref-spend settings asset |
-| `MINTING_DATA_HANDLE_NAME` | `hal_root@handle_settings` | Minting-data asset |
-| `MPT_MINTED_VALUE` | `minted` | Trie marker for consumed/minted asset names |
-| `ROYALTY_ASSET_FULL_NAME` | `001f4d70526f79616c7479` | Royalty token full asset name |
+| `PREFIX_100` | `000643b0` | Label for reference tokens paired with minted user assets |
+| `PREFIX_222` | `000de140` | Label for user-facing H.A.L. NFTs |
+| `SETTINGS_HANDLE_NAME` | `hal@handle_settings` | Handle that stores the HAL settings datum |
+| `REF_SPEND_SETTINGS_HANDLE_NAME` | `hal_pz@handle_settings` | Handle that stores ref-spend settings |
+| `MINTING_DATA_HANDLE_NAME` | `hal_root@handle_settings` | Handle that stores minting-data roots |
+| `LEGACY_POLICY_ID` | `f0ff48...fb9a` | Existing handle policy used for settings-bearing assets |
+| `MPT_MINTED_VALUE` | `minted` | Marker written back to the asset trie after consumption |
+| `ROYALTY_ASSET_FULL_NAME` | `001f4d70526f79616c7479` | Royalty asset name including the CIP-style label |
 
-Defined in `src/constants/index.ts`.
+These values are defined in `src/constants/index.ts` and are used across both TypeScript and validator logic.
 
-## Core Types
+## Asset Naming Model
 
-### Settings (`src/contracts/types/settings.ts` + `settings_v1.ts`)
-- `Settings`:
-  - `mint_governor: string`
-  - `mint_version: bigint`
-  - `data: UplcData`
-- `SettingsV1`:
-  - `policy_id`
-  - `allowed_minter`
-  - `hal_nft_price`
-  - `minting_data_script_hash`
-  - `orders_spend_script_hash`
-  - `ref_spend_proxy_script_hash`
-  - `ref_spend_governor`
-  - `ref_spend_admin`
-  - `royalty_spend_script_hash`
-  - `minting_start_time`
-  - `payment_address`
+### User NFT assets
+User-facing H.A.L. NFTs use:
+- policy id: the hash of `halmntprx.mint`,
+- asset name: `PREFIX_222 + <utf8-name-hex>`.
 
-### Ref Spend Settings
-- `RefSpendSettingsV1`:
-  - `policy_id`
-  - `ref_spend_admin`
+### Reference assets
+Reference outputs use:
+- the same policy id,
+- asset name: `PREFIX_100 + <utf8-name-hex>`.
 
-### Minting Data (`src/contracts/types/minting_data.ts`)
-- `mpt_root_hash: string`
-- `whitelist_mpt_root_hash: string`
+This pairing lets the system issue a user token and a governed reference token for the same logical H.A.L. asset in one mint flow.
 
-### Proof Types
-- `AssetNameProof = [asset_hex_name, mpt_proof]`
-- `WhitelistProof = [whitelisted_value, mpt_proof]`
-- `Proofs = [AssetNameProof[], WhitelistProof | undefined]`
+### Settings-bearing assets
+Settings, ref-spend settings, and minting-data are stored as handle-backed assets under the legacy handle policy. Their names are stable and human-recognizable because operators need to discover them through the handle API as part of deployment planning and live-state inspection.
 
-### Whitelist Types (`src/contracts/types/whitelist.ts`)
-- `WhitelistedItem`:
-  - `time_gap: number`
-  - `amount: number`
-  - `price: bigint`
-- `WhitelistedValue = WhitelistedItem[]`
+## Core Contract Types
 
-## Datum/Redeemer Encoding Surfaces
-- Settings codecs:
-  - `buildSettingsData`, `decodeSettingsDatum`
-  - `buildSettingsV1Data`, `decodeSettingsV1Data`
-- Minting data codecs:
-  - `buildMintingData`, `decodeMintingDataDatum`
-  - mint redeemers include proof lists and whitelist proof payloads
-- Orders codecs:
-  - `buildOrderDatumData`, `decodeOrderDatumData`
-  - cancel/refund/execute redeemers for `orders_spend`
-- Royalty/ref datums:
-  - royalty datum encoding for royalty spend output
-  - reference datum path requires inline datum replacement via ref-spend flow
+### Settings
+`src/contracts/types/settings.ts` models the wrapper object, while `settings_v1.ts` models the payload that matters operationally.
 
-## Deployment Data Shape
+`Settings` contains:
+- `mint_governor: string`
+- `mint_version: bigint`
+- `data: UplcData`
 
-`DeployData` from `src/txs/deploy.ts` includes:
-- `optimizedCbor`
-- `unOptimizedCbor?`
-- `datumCbor?`
-- `validatorHash`
-- optional `policyId`, `scriptAddress`, `scriptStakingAddress`
+`SettingsV1` expands `data` into:
+- `policy_id`
+- `allowed_minter`
+- `hal_nft_price`
+- `minting_data_script_hash`
+- `orders_spend_script_hash`
+- `ref_spend_proxy_script_hash`
+- `ref_spend_governor`
+- `ref_spend_admin`
+- `royalty_spend_script_hash`
+- `minting_start_time`
+- `payment_address`
 
-`DeployedScripts` includes script details + reference UTxOs for all 7 HAL contracts.
+This split matters because the outer record identifies the current mint governor and version, while the inner payload provides the concrete routing and pricing values used by runtime transaction builders.
+
+### Ref-spend settings
+The ref-spend settings record is smaller by design. `RefSpendSettingsV1` contains:
+- `policy_id`
+- `ref_spend_admin`
+
+The outer wrapper additionally carries `ref_spend_governor`, which ties the settings asset to the governing validator hash.
+
+### Minting data
+`MintingData` currently stores:
+- `mpt_root_hash`
+- `whitelist_mpt_root_hash`
+
+This is the minimal on-chain summary needed to prove:
+- which collection inventory state is active,
+- which whitelist allocation state is active.
+
+### Orders
+`OrderDatum` contains:
+- `owner_key_hash`
+- `destination_address`
+- `amount`
+
+The datum deliberately does not embed final metadata. It only identifies who owns the order, where minted assets should go, and how many assets are requested.
+
+## Proof Types
+
+### Asset-name proof
+`AssetNameProof = [asset_hex_name, mpt_proof]`
+
+This proves that a requested asset name existed in the inventory trie before mint and allows the validator to check the root transition as that entry becomes consumed.
+
+### Whitelist proof
+`WhitelistProof = [whitelisted_value, mpt_proof]`
+
+This proves the current whitelist allocation for a destination address and allows the contract to verify any consumed discounted entitlement.
+
+### Mint proof bundle
+`Proofs = [AssetNameProof[], WhitelistProof | undefined]`
+
+Each aggregated order in a mint transaction carries the asset proofs for that destination and, if needed, the whitelist proof required to justify early or discounted access.
+
+## Whitelist Value Model
+Whitelist state is not a single counter. It is a list of entries so the system can express multiple windows or pricing rules for a single address.
+
+`WhitelistedItem` contains:
+- `time_gap: number`
+- `amount: number`
+- `price: bigint`
+
+`WhitelistedValue` is an array of those items.
+
+At mint-preparation time, the runtime:
+1. computes the gap between `minting_start_time` and the requested mint time,
+2. filters to the entries currently eligible,
+3. checks whether the order amount and paid lovelace are consistent with those entries,
+4. updates the local whitelist trie if any discounted allocation is consumed.
+
+## Runtime Aggregation Shapes
+
+### Valid order
+The order-preparation code promotes decodable, bounded order inputs into `ValidOrder` records that carry:
+- original `txInput`,
+- destination address,
+- amount,
+- whether a whitelist proof is required,
+- whether the order was already assigned to a batch.
+
+### Aggregated order
+An `AggregatedOrder` represents a mint-ready destination-level grouping rather than a raw order UTxO. This is the shape `prepareMintTransaction` expects after sorting and batching.
+
+### Asset info
+Mint preparation also relies on `HalAssetInfo`, which pairs:
+- `assetUtf8Name`,
+- `assetDatum`.
+
+This is how the off-chain runtime ties a chosen inventory name to the final metadata/reference datum written into outputs.
+
+## Deployment YAML Schema
+`src/deploymentState.ts` defines the committed desired-state schema. The top-level object contains:
+- `schema_version`
+- `network`
+- `build_parameters`
+- `settings`
+- `assigned_handles`
+- `ignored_settings`
+- `contracts`
+
+### Build parameters
+These values affect derived script hashes:
+- `mint_version`
+- `admin_verification_key_hash`
+- `orders_spend_randomizer`
+- `royalty_spend_admin`
+
+### Settings section
+The `settings` block stores stable desired values for:
+- HAL settings,
+- ref-spend settings,
+- minting-data roots.
+
+### Assigned handles
+This section records the stable handles the repo expects each network to use.
+- `assigned_handles.settings` tracks handle-backed datum assets.
+- `assigned_handles.scripts` tracks current script handles or `null` placeholders.
+
+### Ignored settings
+`ignored_settings` allows the planner to accept intentional variance for fields that are expected to move outside a code or settings rollout, currently the minting-data roots.
+
+### Contracts
+Each contract entry records:
+- `contract_slug`
+- `script_type`
+- `old_script_type`
+- `deployment_handle_slug`
+- `build.contract_name`
+- `build.kind`
+
+The parser intentionally enforces matching slug/script/deployment names because the planner assumes one stable identity per contract.
+
+## Observed Versus Desired State
+Some fields are valid only in planner output or live observations and must never be committed into desired YAML:
+- `current_script_hash`
+- `current_settings_utxo_ref`
+- `current_subhandle`
+- `observed_at`
+- `last_deployed_tx_hash`
+
+This boundary matters because the repo is supposed to express intended steady state, not volatile chain snapshots.
+
+## State Transitions
+
+### Inventory transition
+- Before mint: asset key exists with an empty value.
+- After mint: the same key is rewritten to `minted`.
+
+### Whitelist transition
+- Before mint: address entry contains full remaining whitelist allocations.
+- After discount consumption: one or more entries are reduced or removed according to the amount minted and timing used.
+
+### Deployment transition
+- Before rollout: desired YAML and live state may differ.
+- Planner output: classifies the difference and proposes the post-deploy state.
+- After approved deployment: live scripts and handle-backed settings should converge to the desired state described by the repo.
+
+## Why This Model Matters
+Every major workflow in the repo depends on the same data model being interpreted consistently:
+- validators enforce it on-chain,
+- codecs decode and encode it off-chain,
+- deployment planning compares it across environments,
+- tests assert that the shapes behave correctly under both happy and failure paths.
+
+If a change alters one of these structures without updating the rest, the defect usually appears as either root-hash mismatch, invalid order handling, misrouted outputs, or false-positive deployment drift.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,5 +1,12 @@
 # Spec Docs
 
-- [Technical Spec](./spec.md)
-- [Contract Deployment Pipeline](./contract-deployment-pipeline.md)
-- [Data Model](./data-model.md)
+The spec docs describe how `hal-minting-contracts` is assembled and operated at the implementation level. They are intended for engineers reviewing contract logic, deployment drift, data encodings, and testing coverage.
+
+- [Technical Spec](./spec.md)  
+  High-level architecture, module boundaries, runtime flow, and critical invariants.
+- [Contract Deployment Pipeline](./contract-deployment-pipeline.md)  
+  Desired-state YAML model, drift detection, planner artifacts, and approval boundaries.
+- [Data Model](./data-model.md)  
+  Core constants, handles, datum types, proof shapes, and deployment-state schema.
+- [Validator Catalog](./validator-catalog.md)  
+  Contract-by-contract breakdown of purpose, parameterization, datum/redeemer surfaces, and governing rules.

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -1,97 +1,191 @@
 # Technical Spec
 
-## Architecture
+## Architecture Overview
+`hal-minting-contracts` combines three layers:
 
-### Modules
-- `src/contracts/*`
-  - Blueprint decoding, parameter application, datum/redeemer codecs, and typed structs.
-- `src/txs/*`
-  - Transaction assembly for orders, minting, refunds, deploy, proof, whitelist, royalty, and ref spend.
-- `src/configs/*`
-  - Fetch + decode on-chain settings/minting data via `api.handle.me`.
-- `src/store/*`
-  - Trie helpers for local asset and whitelist state.
-- `scripts/run/*`
-  - Interactive operations for MPT state, settings cbor generation, deploy, and staking registration.
+1. On-chain validator and minting-policy programs in `smart-contract/`.
+2. TypeScript codecs and transaction builders in `src/`.
+3. Operator tooling, deployment planning, and tests in `scripts/`, `deploy/`, and `tests/`.
 
-### External Integrations
-- `api.handle.me` for handle/script metadata and datum retrieval.
-- Blockfrost for UTxO access and transaction context.
+The repo is intentionally split this way so that contract validation rules remain close to the Aiken sources while off-chain assembly, drift detection, and testing can evolve without obscuring the underlying chain invariants.
+
+## Repository Modules
+
+### `smart-contract/`
+- Contains the Aiken validators and libraries for minting, whitelist, royalty, settings, minting-data, and ref-spend logic.
+- Includes contract-level tests under `smart-contract/lib/tests`.
+- Serves as the source of truth for on-chain validation behavior.
+
+### `src/contracts/*`
+- Loads optimized and unoptimized blueprints.
+- Applies parameters to validators.
+- Defines TypeScript types for settings, minting-data, orders, whitelist entries, MPT proofs, and royalty data.
+- Encodes and decodes datum and redeemer payloads so off-chain code can interact with validators safely.
+
+### `src/txs/*`
+- Implements the major transaction-building surfaces:
+  - order request,
+  - order cancel,
+  - order refund,
+  - order aggregation,
+  - mint preparation,
+  - reference datum update,
+  - royalty mint/update,
+  - staking registration,
+  - contract export and deployed-script loading.
+
+### `src/store/*`
+- Wraps the Merkle Patricia Forestry trie helpers used to track collection inventory and whitelist allocations.
+- Provides functions for initialization, inspection, proof printing, inserting, deleting, and bulk filling.
+
+### `src/deploymentState.ts` and `src/deploymentPlan.ts`
+- Define the schema for committed desired-state YAML.
+- Derive expected script hashes from build parameters.
+- Fetch current live scripts and settings via handle API endpoints.
+- Build approval-ready JSON and Markdown artifacts that classify drift.
+
+### `scripts/`
+- Provides interactive utilities for MPT operations, contract export, settings CBOR generation, and staking-address registration.
+- Includes `generateDeploymentPlan.ts`, the repo-local planner entrypoint used by CI.
+
+### `tests/`
+- Combines emulator-backed integration tests with unit tests for deployment planning, desired-state parsing, runtime helpers, and trie-proof utilities.
 
 ## Contract Set
-- `halmntprx.mint`
-- `halmnt.withdraw`
-- `halmntmpt.spend`
-- `halord.spend`
-- `halrefprx.spend`
-- `halref.withdraw`
-- `halroy.spend`
+The current contract suite consists of seven deployable script surfaces:
 
-`deploy` (`src/txs/deploy.ts`) emits script-specific cbor/hash/address payloads and optional parameter datum cbor.
+| Slug | Contract | Kind | Role |
+| --- | --- | --- | --- |
+| `halmntprx` | `halmntprx.mint` | minting policy | Policy id for H.A.L. assets |
+| `halmnt` | `halmnt.withdraw` | withdrawal validator | Governs mint authorization and royalty mint path |
+| `halmntmpt` | `halmntmpt.spend` | spending validator | Holds inventory and whitelist roots |
+| `halord` | `halord.spend` | spending validator | Stores user order UTxOs |
+| `halrefprx` | `halrefprx.spend` | spending validator | Receives reference-token outputs |
+| `halref` | `halref.withdraw` | withdrawal validator | Governs reference datum updates |
+| `halroy` | `halroy.spend` | spending validator | Holds the royalty NFT and royalty datum |
 
-## Transaction Flows
+`src/contracts/config.ts` is the central assembly point that parameterizes these programs and exposes the derived hashes, addresses, and staking credentials needed by the rest of the repo.
 
-### Order Flows (`src/txs/order.ts`)
-- `request`:
-  - validates destination/payment constraints,
-  - decodes settings to resolve orders script hash,
-  - creates order outputs with inline datum.
-- `cancel`:
-  - verifies order input source script,
-  - validates datum owner,
-  - spends order with cancel redeemer and owner signer.
-- `refund`:
-  - validates settings + input source,
-  - enforces refunding payment credential when datum decodes,
-  - requires allowed minter signer.
+## Runtime Flow
 
-### Order Preparation (`src/txs/prepareOrders.ts`)
-- Filters invalid order UTxOs.
-- Aggregates valid orders by destination and tx limits.
-- Applies whitelist availability and time-gap logic.
-- Returns:
-  - `aggregatedOrdersList`,
-  - `unpickedOrderTxInputs`,
-  - `invalidOrderTxInputs`.
+### 1. Load environment and network context
+`src/constants/index.ts` loads `.env.<NODE_ENV>.local` and exposes:
+- `NETWORK`,
+- `BLOCKFROST_API_KEY`,
+- `KORA_USER_AGENT`,
+- `HANDLE_ME_API_KEY`,
+- optional `HANDLE_API_ENDPOINT`.
 
-### Mint Preparation (`src/txs/prepareMint.ts`)
-- Validates local asset trie and whitelist trie roots against on-chain minting-data roots.
-- Builds per-order asset-name proofs and optional whitelist proofs.
-- Updates local trie states and produces updated minting-data datum.
-- Assembles tx with:
-  - script references,
-  - minting_data spend/relock,
-  - order spend execution,
-  - mint policy tokens,
-  - payment/ref/user outputs,
-  - mint governor withdraw redeemer.
+`NETWORK_HOST` and `HANDLE_API_ENDPOINT` are derived from the requested network so handle lookups target `preview`, `preprod`, or mainnet endpoints correctly.
 
-### Ref and Royalty Admin Flows
-- `src/txs/ref_spend.ts`:
-  - updates reference token datum through ref-spend governance path.
-- `src/txs/royalty.ts`:
-  - mints one royalty NFT and updates royalty datum with admin signature.
+### 2. Resolve settings and live scripts
+Before minting or admin actions, off-chain code fetches:
+- the HAL settings handle,
+- the ref-spend settings handle,
+- the minting-data handle,
+- deployed reference script UTxOs.
 
-### Staking Registration
-- `registerStakingAddresses` builds one tx containing registration certs for multiple staking addresses.
+These fetches bridge the repo's local transaction builders to the live chain state actually governing mint execution.
+
+### 3. Validate or aggregate orders
+Order handling starts in `src/txs/order.ts` and `src/txs/prepareOrders.ts`.
+- `request` builds order outputs and validates basic bounds.
+- `cancel` verifies script source and owner signer expectations.
+- `refund` verifies script source, settings authorization, and refund credential alignment.
+- `prepareOrders` classifies incoming order UTxOs into valid, invalid, and unpicked buckets, then groups valid orders into mint-sized batches.
+
+### 4. Build mint proofs and outputs
+`prepareMintTransaction` in `src/txs/prepareMint.ts` is the core mint-preparation path. It:
+- sorts aggregated orders deterministically,
+- decodes settings and minting-data,
+- compares on-chain roots to the local inventory and whitelist tries,
+- consumes asset names from the local inventory trie by changing values to `minted`,
+- optionally consumes whitelist entitlements,
+- creates minting-data redeemers and replacement datum,
+- constructs user outputs for `222` assets and reference outputs for `100` assets.
+
+The function returns a transaction builder plus side data that the caller uses to finalize outputs and later persist the updated trie state.
+
+### 5. Execute governed admin flows
+Separate builder modules handle:
+- royalty mint and royalty datum update,
+- reference datum update,
+- staking-address registration,
+- contract export and deployed-script retrieval.
+
+This separation prevents admin-only actions from being disguised as part of the user mint flow.
+
+## State Model
+
+### Inventory trie
+The inventory trie contains pre-defined H.A.L. asset names as keys. Before mint, values are empty. After mint, values become the `minted` marker. This gives the validator a deterministic way to prove that:
+- an asset name existed in the approved inventory,
+- the asset had not already been consumed,
+- the root hash changes correctly after mint.
+
+### Whitelist trie
+The whitelist trie is keyed by destination address and stores a list of whitelist entries, each describing:
+- early-access time gap,
+- amount entitlement,
+- discounted price.
+
+Mint preparation computes which subset of those entries is currently usable based on transaction time and order size, then generates the proof required to update the root.
+
+### Handle-backed settings
+Three handle-backed assets matter operationally:
+- `hal@handle_settings`,
+- `hal_pz@handle_settings`,
+- `hal_root@handle_settings`.
+
+These handles carry the settings datum, the ref-spend settings datum, and the minting-data datum respectively. The deployment planner reads them to compare committed desired state against live chain state.
 
 ## Critical Invariants
-- Minting asset names must exist in pre-filled trie and transition from available to minted state.
-- Both `mpt_root_hash` and `whitelist_mpt_root_hash` must match local trie roots before mint tx creation.
-- Refund/cancel paths enforce script source and credential constraints.
-- Whitelist discount consumption must remain deterministic under `minting_start_time` gaps.
+- Only the allowed minter may execute user NFT minting.
+- Minting requires both the settings reference input and the minting-data spend.
+- Local inventory trie root must equal on-chain `mpt_root_hash` before mint preparation.
+- Local whitelist trie root must equal on-chain `whitelist_mpt_root_hash` before mint preparation.
+- Orders must come from the deployed orders script and carry decodable inline data.
+- Refunds must target the owner's payment credential when the order datum can be decoded.
+- Reference outputs must route to the ref-spend proxy path so governed metadata updates remain possible.
+- Deployment desired-state YAML must not include observed-only fields such as current UTxO refs or observed timestamps.
 
-## Runtime Configuration
+## Deployment And Drift Detection
+The deployment planner turns desired YAML plus live chain observations into three artifacts:
+- `summary.json`,
+- `summary.md`,
+- `deployment-plan.json`.
 
-| Variable | Purpose |
-| --- | --- |
-| `BLOCKFROST_API_KEY` | Network-aware UTxO lookups |
-| `KORA_USER_AGENT` | Required user-agent for handle API requests |
-| `HANDLE_ME_API_KEY` | Handle API authentication |
-| `HANDLE_API_ENDPOINT` | Optional API endpoint override |
-| `NETWORK` / `NODE_ENV` | Network and env profile selection |
+The planner does not currently emit transaction CBOR. Instead, it tells reviewers whether each repo-owned contract or settings handle has:
+- `no_change`,
+- `script_hash_only`,
+- `settings_only`.
 
-## Testing and Coverage
-- Integration suite: `tests/mint.test.ts`.
-- Guardrail script: `test_coverage.sh`.
-- Coverage report artifact: `test_coverage.report`.
+For script drift, the plan also proposes the next SubHandle allocation under the `@handlecontract` namespace. This is critical because new script hashes must move to a new handle rather than silently reusing the old one.
+
+## Source-Of-Truth Rules
+The deployment planner uses `deploy/*.yaml` as the canonical desired state. The interactive config modules in `scripts/configs/*.ts` remain helpful for manual workflows, but they are not what CI uses to determine rollout drift. Engineers should therefore reason about the repo in this order:
+
+1. Desired deployment YAML for what should be live.
+2. Live chain and handle state for what is live now.
+3. Interactive config scripts for ad hoc operator utilities.
+
+If those sources diverge, the divergence is itself operationally important and should be documented or corrected rather than ignored.
+
+## External Dependencies
+- `@helios-lang/*` packages for ledger, UPLC, and tx-building primitives.
+- `@aiken-lang/merkle-patricia-forestry` for inventory and whitelist tries.
+- Blockfrost for live UTxO access.
+- `api.handle.me` and its preview/preprod variants for script and handle-backed datum discovery.
+- `@koralabs/kora-labs-common` for shared script-detail types.
+
+## Verification Surfaces
+
+### CI workflows
+- `.github/workflows/test.yml` runs lint, Aiken tests, and the TypeScript/Vitest suite.
+- `.github/workflows/deployment-plan.yml` runs the repo-local deployment planner through the shared deployment workflow.
+
+### Test types
+- Emulator integration tests validate minting, whitelist usage, royalty flows, and ref-datum updates.
+- Unit tests validate deployment-state parsing, live-state fetch behavior, drift summarization, handle allocation, and utility logic.
+
+Together these tests make the repo more than a contract dump. They prove that the off-chain assembly and deployment abstractions still match the contract model the repo claims to own.

--- a/docs/spec/validator-catalog.md
+++ b/docs/spec/validator-catalog.md
@@ -1,0 +1,217 @@
+# Validator Catalog
+
+## Purpose
+The H.A.L. minting system is distributed across seven contract surfaces rather than a single validator. That separation is intentional. It keeps policy identity, user orders, mutable reference data, royalty governance, and minting-state tracking from collapsing into one brittle script.
+
+This document summarizes each contract in terms of:
+- what it controls,
+- what parameters affect its hash,
+- what datum or redeemer surfaces matter,
+- which invariants it enforces in the broader system.
+
+## Contract Summary Table
+
+| Slug | Contract | Primary job |
+| --- | --- | --- |
+| `halmntprx` | `halmntprx.mint` | Mints the H.A.L. policy assets and ties minting to the mint governor |
+| `halmnt` | `halmnt.withdraw` | Authorizes mint actions and royalty minting via a staking validator path |
+| `halmntmpt` | `halmntmpt.spend` | Stores and updates inventory and whitelist root hashes |
+| `halord` | `halord.spend` | Holds user order UTxOs until cancellation, refund, or batch execution |
+| `halrefprx` | `halrefprx.spend` | Receives reference-token outputs that back governed metadata updates |
+| `halref` | `halref.withdraw` | Authorizes reference-datum update flows |
+| `halroy` | `halroy.spend` | Stores the royalty NFT and royalty datum |
+
+## `halmntprx.mint`
+
+### Role
+This is the policy id for H.A.L. user assets and reference assets. If its parameters change, the policy id changes.
+
+### Parameterization
+- `mint_version`
+
+Because the policy hash is part of the collection identity, changes here are high impact and should be treated as collection-level events rather than ordinary deployment updates.
+
+### Datum and redeemer
+- datum: none
+- redeemer: unconstrained at the outer surface, but effective use is gated by the associated mint governor
+
+### Key rules
+- The minting policy expects the HAL settings asset to be present in reference inputs.
+- The parameterized version must align with the version stored in the settings record.
+- The mint governor withdrawal validator must also execute, which means the policy alone is not enough to mint.
+
+### Operational implication
+Engineers must assume that redeploying this script is a breaking identity change. It is not equivalent to rotating a spending validator while keeping the collection policy constant.
+
+## `halmnt.withdraw`
+
+### Role
+This withdrawal validator is the mint governor. It authorizes H.A.L. user mints and the royalty mint path without forcing the policy id itself to change when other logic evolves.
+
+### Parameterization
+- none
+
+### Redeemers
+- `MintNFTs`
+- `BurnNFTs`
+- `MintRoyaltyNFT`
+
+### Key rules
+- `MintNFTs` requires the HAL settings handle in reference inputs.
+- `MintNFTs` requires the minting-data UTxO to be spent, ensuring root-hash state changes participate in the same transaction.
+- `MintRoyaltyNFT` requires the allowed minter signature from settings.
+- `MintRoyaltyNFT` allows minting only one royalty NFT and requires it to be sent to the royalty-spend validator.
+- Burn support is reserved but not productized yet.
+
+### Operational implication
+This validator is the gatekeeper that turns "a policy exists" into "a mint is allowed now under current settings." If the settings handle or minting-data spend is absent, the mint must fail.
+
+## `halmntmpt.spend`
+
+### Role
+This spending validator holds the minting-data asset that tracks both the collection inventory root and the whitelist root. It is the state transition point that prevents double minting and invalid whitelist consumption.
+
+### Parameterization
+- `admin_verification_key_hash`
+
+This parameter defines the admin authority that can update root-hash state outside a normal mint path when needed.
+
+### Datum
+The datum is treated permissively at the outer type boundary, but operationally it represents `MintingData`:
+- `mpt_root_hash`
+- `whitelist_mpt_root_hash`
+
+### Redeemers
+- `Mint(List<Proofs>)`
+- `UpdateMPT`
+
+### Key rules for `Mint`
+- HAL settings must be present in reference inputs.
+- The allowed minter signature must be present.
+- The spending input must carry the minting-data asset.
+- Order inputs are aggregated by destination address and checked against the supplied proofs.
+- User outputs must match the aggregated order amounts.
+- Asset proofs must show that each asset existed in the inventory trie before being flipped to minted.
+- If a whitelist proof is provided, the validator verifies that the proof matches the destination address and the discounted allocation being consumed.
+
+### Key rules for `UpdateMPT`
+- Admin authority is required.
+- The path exists to maintain root-hash state without pretending a user mint occurred.
+
+### Operational implication
+This is the most stateful contract in the system. Local trie drift versus on-chain root drift is a hard blocker because the contract assumes the off-chain runtime built proofs against the exact live roots.
+
+## `halord.spend`
+
+### Role
+This validator stores user order UTxOs between request time and batch execution.
+
+### Parameterization
+- HAL policy id
+- optional orders-spend randomizer
+
+The randomizer exists because changing it changes the script hash without changing the logical purpose of the contract.
+
+### Datum
+`OrderDatum`:
+- `owner_key_hash`
+- `destination_address`
+- `amount`
+
+### Redeemers
+The TypeScript builders expose three meaningful flows:
+- cancel order
+- refund order
+- execute order as part of mint preparation
+
+### Key rules
+- Order requests pay lovelace and inline datum to the orders script.
+- Cancel requires the order owner signer path.
+- Refund requires the governed minter path and must respect the owner's payment credential.
+- Execute occurs only in a mint transaction that also satisfies the mint and minting-data validators.
+
+### Operational implication
+The orders script is where user intent waits. Any ambiguity in order decoding or payment validation turns into either an invalid order bucket or a refund requirement, not a silent partial mint.
+
+## `halrefprx.spend`
+
+### Role
+This validator is the landing zone for reference tokens minted alongside user NFTs.
+
+### Parameterization
+- none
+
+### Datum and redeemer
+The contract exists primarily as a routing and governance anchor. The corresponding TypeScript flow later retrieves reference UTxOs from this address so a governed update can replace the datum.
+
+### Key rules
+- Mint preparation routes every reference token output here rather than directly to a user wallet.
+- The validator works together with the ref-spend governor and ref-spend settings handle to ensure metadata changes stay controlled.
+
+### Operational implication
+Without this separation, the system would lose a clean way to mutate reference metadata while leaving user NFTs untouched.
+
+## `halref.withdraw`
+
+### Role
+This withdrawal validator governs the reference-datum update path.
+
+### Parameterization
+- none
+
+### Runtime usage
+The TypeScript `update` flow in `src/txs/ref_spend.ts` uses:
+- the reference-token UTxO,
+- deployed ref-spend scripts,
+- the ref-spend settings asset,
+- the ref-spend admin signer path.
+
+### Key rules
+- A valid reference token for the requested asset must be present.
+- Governance is derived from the ref-spend settings record rather than from user ownership.
+- The path updates inline datum while preserving the governed reference-token model.
+
+### Operational implication
+This keeps metadata correction or post-mint evolution separate from end-user order handling. A user owning the visible NFT does not automatically imply authority to rewrite the reference datum.
+
+## `halroy.spend`
+
+### Role
+This validator stores the royalty NFT and its datum so royalty policy remains a governed on-chain object.
+
+### Parameterization
+- `royalty_spend_admin`
+
+Changing this parameter changes the validator hash because it changes who can govern the royalty datum.
+
+### Runtime usage
+The TypeScript layer exposes:
+- `mintRoyalty`
+- `updateRoyalty`
+
+The first mints the one royalty NFT through the mint governor path. The second spends the royalty UTxO and replaces the datum using the royalty admin signer.
+
+### Key rules
+- Only one royalty NFT is minted.
+- The allowed minter is required for the initial mint path.
+- The royalty admin is required for updates.
+- The royalty NFT must remain at the royalty-spend validator so governed datum replacement stays enforceable.
+
+### Operational implication
+Royalty state is explicit and chain-governed. It is not hidden inside off-chain metadata conventions or assumed wallet storage.
+
+## Cross-Contract Invariants
+- The mint policy and mint governor must agree on versioned mint authority.
+- The mint governor and minting-data validator must participate together for user minting.
+- Order execution is only meaningful when coupled with the minting-data and mint governor paths.
+- Reference tokens must route through ref-spend governance rather than directly to users.
+- Royalty issuance is a governed one-time mint plus governed updates.
+
+## Why The Split Matters
+The seven-contract design may look heavier than a minimal NFT mint flow, but it buys clear boundaries:
+- collection identity is distinct from mint governance,
+- user order escrow is distinct from inventory state,
+- metadata governance is distinct from end-user holdings,
+- deployment review can reason about each contract independently.
+
+That separation is one of the main reasons the repo can support both safe minting and approval-friendly deployment planning.

--- a/tests/prepareOrders.unit.ts
+++ b/tests/prepareOrders.unit.ts
@@ -1,0 +1,256 @@
+import {
+  makeAddress,
+  makeInlineTxOutputDatum,
+  makePubKeyHash,
+  makeValidatorHash,
+  makeValue,
+} from "@helios-lang/ledger";
+import { makeByteArrayData, makeConstrData } from "@helios-lang/uplc";
+import { describe, expect, test, vi } from "vitest";
+
+const VOID_DATA = makeConstrData(0, []);
+
+const makeOrderInput = (
+  amount: number,
+  lovelace: bigint,
+  destinationAddress = makeAddress(false, makePubKeyHash("1".repeat(56)))
+) => {
+  const orderDatum = {
+    owner_key_hash: destinationAddress.spendingCredential.toHex(),
+    destination_address: destinationAddress,
+    amount,
+  };
+
+  return {
+    id: { toString: () => `tx-${amount}-${lovelace}` },
+    address: makeAddress(false, makeValidatorHash("a".repeat(56))),
+    datum: Object.assign(makeInlineTxOutputDatum(VOID_DATA), {
+      __orderDatum: orderDatum,
+    }),
+    value: makeValue(lovelace),
+  };
+};
+
+describe("prepare orders coverage", () => {
+  test("orderToConsecutiveSum7 prefers shortest consecutive partners while preserving order", async () => {
+    const { orderToConsecutiveSum7 } = await import("../src/txs/prepareOrders.js");
+    const orders = [1, 2, 4, 3, 6, 1, 8].map((amount, index) => ({
+      txInput: { id: { toString: () => `tx-${index}` } },
+      datum: { amount },
+    })) as never;
+
+    const sorted = orderToConsecutiveSum7(orders).map(({ datum }) => datum.amount);
+
+    expect(sorted).toEqual([1, 6, 2, 4, 1, 3, 8]);
+  });
+
+  test("aggregateOrderTxInputs separates valid, unpicked, and invalid orders", async () => {
+    vi.resetModules();
+    vi.doMock("../src/contracts/index.js", async (importOriginal) => {
+      const original = await importOriginal<typeof import("../src/contracts/index.js")>();
+      return {
+        ...original,
+        decodeOrderDatumData: vi.fn((datum) => (datum as { __orderDatum?: unknown }).__orderDatum ?? {
+          owner_key_hash: "1".repeat(56),
+          destination_address: makeAddress(false, makePubKeyHash("1".repeat(56))),
+          amount: 1,
+        }),
+      };
+    });
+
+    const { aggregateOrderTxInputs } = await import("../src/txs/prepareOrders.js");
+    const destinationAddress = makeAddress(false, makePubKeyHash("1".repeat(56)));
+    const orderInputs = [
+      makeOrderInput(2, 20n, destinationAddress),
+      makeOrderInput(1, 10n, destinationAddress),
+      makeOrderInput(3, 30n, destinationAddress),
+    ];
+
+    const result = await aggregateOrderTxInputs({
+      isMainnet: false,
+      orderTxInputs: orderInputs as never,
+      settingsV1: {
+        hal_nft_price: 10n,
+        minting_start_time: 2_000,
+        orders_spend_script_hash: "a".repeat(56),
+      } as never,
+      whitelistDB: { get: vi.fn(async () => null) } as never,
+      mintingTime: 3_000,
+      maxOrderAmountInOneTx: 3,
+      maxTxsPerLambda: 1,
+      remainingHals: 4,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.aggregatedOrdersList).toHaveLength(1);
+    expect(result.data.aggregatedOrdersList[0][0].amount).toBe(3);
+    expect(result.data.unpickedOrderTxInputs).toHaveLength(0);
+    expect(result.data.invalidOrderTxInputs).toHaveLength(1);
+    expect(result.data.invalidOrderTxInputs[0].id.toString()).toBe("tx-3-30");
+  });
+
+  test("prepareOrders includes initial invalid orders and aggregation-time invalid orders", async () => {
+    vi.resetModules();
+    vi.doMock("../src/contracts/index.js", async (importOriginal) => {
+      const original = await importOriginal<typeof import("../src/contracts/index.js")>();
+      return {
+        ...original,
+        decodeOrderDatumData: vi.fn((datum) => (datum as { __orderDatum?: unknown }).__orderDatum ?? {
+          owner_key_hash: "1".repeat(56),
+          destination_address: makeAddress(false, makePubKeyHash("1".repeat(56))),
+          amount: 1,
+        }),
+      };
+    });
+
+    const { prepareOrders } = await import("../src/txs/prepareOrders.js");
+    const destinationAddress = makeAddress(false, makePubKeyHash("1".repeat(56)));
+    const invalidAddressOrder = {
+      ...makeOrderInput(1, 10n, destinationAddress),
+      address: makeAddress(false, makeValidatorHash("b".repeat(56))),
+    };
+    const zeroAmountOrder = makeOrderInput(0, 10n, destinationAddress);
+    const validOrder = makeOrderInput(1, 10n, destinationAddress);
+
+    const result = await prepareOrders({
+      isMainnet: false,
+      orderTxInputs: [invalidAddressOrder, zeroAmountOrder, validOrder] as never,
+      settingsV1: {
+        hal_nft_price: 10n,
+        minting_start_time: 2_000,
+        orders_spend_script_hash: "a".repeat(56),
+      } as never,
+      whitelistDB: { get: vi.fn(async () => null) } as never,
+      mintingTime: 3_000,
+      maxOrderAmountInOneTx: 3,
+      maxTxsPerLambda: 2,
+      remainingHals: 3,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data.aggregatedOrdersList).toHaveLength(1);
+    expect(result.data.invalidOrderTxInputs.map((input) => input.id.toString())).toEqual([
+      invalidAddressOrder.id.toString(),
+      zeroAmountOrder.id.toString(),
+    ]);
+  });
+
+  test("prepareOrders returns aggregation failures with context", async () => {
+    vi.resetModules();
+    let decodeCalls = 0;
+    vi.doMock("../src/contracts/index.js", async (importOriginal) => {
+      const original = await importOriginal<typeof import("../src/contracts/index.js")>();
+      return {
+        ...original,
+        decodeOrderDatumData: vi.fn((datum) => {
+          decodeCalls += 1;
+          if (decodeCalls > 1) {
+            throw new Error("bad datum");
+          }
+          return (datum as { __orderDatum?: unknown }).__orderDatum;
+        }),
+      };
+    });
+
+    const { prepareOrders } = await import("../src/txs/prepareOrders.js");
+    const result = await prepareOrders({
+      isMainnet: false,
+      orderTxInputs: [makeOrderInput(1, 10n)] as never,
+      settingsV1: {
+        hal_nft_price: 10n,
+        minting_start_time: 2_000,
+        orders_spend_script_hash: "a".repeat(56),
+      } as never,
+      whitelistDB: { get: vi.fn(async () => null) } as never,
+      mintingTime: 1_000,
+      maxOrderAmountInOneTx: 3,
+      maxTxsPerLambda: 2,
+      remainingHals: 3,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.message).toContain("Failed to aggregate orders");
+    expect(result.error.message).toContain("bad datum");
+  });
+
+  test("contract data builders encode MPT and minting proof redeemers", async () => {
+    const {
+      buildMPTProofData,
+      buildMPTProofStepData,
+      buildMintingDataMintRedeemer,
+      buildMintingDataUpdateMPTRedeemer,
+      decodeWhitelistedValueFromCBOR,
+      makeWhitelistedValueData,
+    } = await import("../src/contracts/index.js");
+
+    const proof = [
+      { type: "branch", skip: 1, neighbors: "aa" },
+      { type: "fork", skip: 2, neighbor: { nibble: 3, prefix: "bb", root: "cc" } },
+      { type: "leaf", skip: 4, key: "dd", value: "ee" },
+    ] as const;
+    const whitelistedValue = [{ time_gap: 5, amount: 2, price: 3n }];
+
+    expect(buildMPTProofData([...proof] as never).kind).toBe("list");
+    expect(buildMPTProofStepData(proof[0] as never).kind).toBe("constr");
+    expect(buildMPTProofStepData(proof[1] as never).kind).toBe("constr");
+    expect(buildMPTProofStepData(proof[2] as never).kind).toBe("constr");
+    expect(buildMintingDataMintRedeemer([[[["68616c", [...proof]], [whitelistedValue, [...proof]]]]] as never).kind).toBe("constr");
+    expect(buildMintingDataUpdateMPTRedeemer().kind).toBe("constr");
+
+    const encodedWhitelist = makeWhitelistedValueData(whitelistedValue).toCbor();
+    const decoded = decodeWhitelistedValueFromCBOR(Buffer.from(encodedWhitelist));
+    expect(decoded.ok).toBe(true);
+    if (decoded.ok) expect(decoded.data).toEqual(whitelistedValue);
+    expect(decodeWhitelistedValueFromCBOR(Buffer.from("ff", "hex")).ok).toBe(false);
+  });
+
+  test("order datum and settings datum builders round trip standard shapes", async () => {
+    vi.resetModules();
+    vi.doUnmock("../src/contracts/index.js");
+    const {
+      buildOrderDatumData,
+      buildRefSpendSettingsData,
+      buildRoyaltyFlagCIP68ExtraData,
+      buildSettingsData,
+      decodeOrderDatumData,
+      decodeRefSpendSettingsDatum,
+      decodeSettingsDatum,
+    } = await import("../src/contracts/index.js");
+    const destinationAddress = makeAddress(false, makePubKeyHash("1".repeat(56)));
+
+    const orderDatum = {
+      owner_key_hash: "2".repeat(56),
+      destination_address: destinationAddress,
+      amount: 3,
+    };
+    expect(
+      decodeOrderDatumData(makeInlineTxOutputDatum(buildOrderDatumData(orderDatum)), false)
+    ).toMatchObject({ owner_key_hash: orderDatum.owner_key_hash, amount: 3 });
+
+    const settingsDatum = makeInlineTxOutputDatum(
+      buildSettingsData({
+        mint_governor: "3".repeat(56),
+        mint_version: 1n,
+        data: makeByteArrayData("aa"),
+      })
+    );
+    expect(decodeSettingsDatum(settingsDatum)).toMatchObject({
+      mint_governor: "3".repeat(56),
+      mint_version: 1n,
+    });
+
+    const refSpendDatum = makeInlineTxOutputDatum(
+      buildRefSpendSettingsData({
+        ref_spend_governor: "4".repeat(56),
+        data: makeByteArrayData("bb"),
+      })
+    );
+    expect(decodeRefSpendSettingsDatum(refSpendDatum)).toMatchObject({
+      ref_spend_governor: "4".repeat(56),
+    });
+    expect(buildRoyaltyFlagCIP68ExtraData().kind).toBe("constr");
+  });
+});


### PR DESCRIPTION
Lesson: reused coverage-rotation-local-tooling-first after discovering repo-local Vitest scripts, coverage harness, CI wiring, and stale coverage report. Added focused unit coverage for prepare-order aggregation and contract data builders.

Verify: npm test passed from /home/jesse/src/koralabs/hal-minting-contracts after the new tests were added. npm run test:unit also passed.